### PR TITLE
Comparing code changes after disabling payload flattening

### DIFF
--- a/sdk/resourcemanager/Azure.ResourceManager/src/Resources/Generated/ResourceLinkCollection.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager/src/Resources/Generated/ResourceLinkCollection.cs
@@ -54,22 +54,26 @@ namespace Azure.ResourceManager.Resources
         /// OperationId: ResourceLinks_CreateOrUpdate
         /// <summary> Creates or updates a resource link between the specified resources. </summary>
         /// <param name="linkId"> The fully qualified ID of the resource link. Use the format, /subscriptions/{subscription-id}/resourceGroups/{resource-group-name}/{provider-namespace}/{resource-type}/{resource-name}/Microsoft.Resources/links/{link-name}. For example, /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myGroup/Microsoft.Web/sites/mySite/Microsoft.Resources/links/myLink. </param>
-        /// <param name="properties"> Properties for resource link. </param>
+        /// <param name="parameters"> Parameters for creating or updating a resource link. </param>
         /// <param name="waitForCompletion"> Waits for the completion of the long running operations. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="linkId"/> is null. </exception>
-        public virtual ResourceLinkCreateOrUpdateOperation CreateOrUpdate(bool waitForCompletion, ResourceIdentifier linkId, ResourceLinkProperties properties = null, CancellationToken cancellationToken = default)
+        /// <exception cref="ArgumentNullException"> <paramref name="linkId"/> or <paramref name="parameters"/> is null. </exception>
+        public virtual ResourceLinkCreateOrUpdateOperation CreateOrUpdate(bool waitForCompletion, ResourceIdentifier linkId, ResourceLinkData parameters, CancellationToken cancellationToken = default)
         {
             if (linkId == null)
             {
                 throw new ArgumentNullException(nameof(linkId));
+            }
+            if (parameters == null)
+            {
+                throw new ArgumentNullException(nameof(parameters));
             }
 
             using var scope = _clientDiagnostics.CreateScope("ResourceLinkCollection.CreateOrUpdate");
             scope.Start();
             try
             {
-                var response = _resourceLinksRestClient.CreateOrUpdate(linkId, properties, cancellationToken);
+                var response = _resourceLinksRestClient.CreateOrUpdate(linkId, parameters, cancellationToken);
                 var operation = new ResourceLinkCreateOrUpdateOperation(Parent, response);
                 if (waitForCompletion)
                     operation.WaitForCompletion(cancellationToken);
@@ -87,22 +91,26 @@ namespace Azure.ResourceManager.Resources
         /// OperationId: ResourceLinks_CreateOrUpdate
         /// <summary> Creates or updates a resource link between the specified resources. </summary>
         /// <param name="linkId"> The fully qualified ID of the resource link. Use the format, /subscriptions/{subscription-id}/resourceGroups/{resource-group-name}/{provider-namespace}/{resource-type}/{resource-name}/Microsoft.Resources/links/{link-name}. For example, /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myGroup/Microsoft.Web/sites/mySite/Microsoft.Resources/links/myLink. </param>
-        /// <param name="properties"> Properties for resource link. </param>
+        /// <param name="parameters"> Parameters for creating or updating a resource link. </param>
         /// <param name="waitForCompletion"> Waits for the completion of the long running operations. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="linkId"/> is null. </exception>
-        public async virtual Task<ResourceLinkCreateOrUpdateOperation> CreateOrUpdateAsync(bool waitForCompletion, ResourceIdentifier linkId, ResourceLinkProperties properties = null, CancellationToken cancellationToken = default)
+        /// <exception cref="ArgumentNullException"> <paramref name="linkId"/> or <paramref name="parameters"/> is null. </exception>
+        public async virtual Task<ResourceLinkCreateOrUpdateOperation> CreateOrUpdateAsync(bool waitForCompletion, ResourceIdentifier linkId, ResourceLinkData parameters, CancellationToken cancellationToken = default)
         {
             if (linkId == null)
             {
                 throw new ArgumentNullException(nameof(linkId));
+            }
+            if (parameters == null)
+            {
+                throw new ArgumentNullException(nameof(parameters));
             }
 
             using var scope = _clientDiagnostics.CreateScope("ResourceLinkCollection.CreateOrUpdate");
             scope.Start();
             try
             {
-                var response = await _resourceLinksRestClient.CreateOrUpdateAsync(linkId, properties, cancellationToken).ConfigureAwait(false);
+                var response = await _resourceLinksRestClient.CreateOrUpdateAsync(linkId, parameters, cancellationToken).ConfigureAwait(false);
                 var operation = new ResourceLinkCreateOrUpdateOperation(Parent, response);
                 if (waitForCompletion)
                     await operation.WaitForCompletionAsync(cancellationToken).ConfigureAwait(false);

--- a/sdk/resourcemanager/Azure.ResourceManager/src/Resources/Generated/RestOperations/ResourceLinksRestOperations.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager/src/Resources/Generated/RestOperations/ResourceLinksRestOperations.cs
@@ -103,7 +103,7 @@ namespace Azure.ResourceManager.Resources
             }
         }
 
-        internal HttpMessage CreateCreateOrUpdateRequest(string linkId, ResourceLinkProperties properties)
+        internal HttpMessage CreateCreateOrUpdateRequest(string linkId, ResourceLinkData parameters)
         {
             var message = _pipeline.CreateMessage();
             var request = message.Request;
@@ -116,12 +116,8 @@ namespace Azure.ResourceManager.Resources
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             request.Headers.Add("Content-Type", "application/json");
-            var model = new ResourceLinkData()
-            {
-                Properties = properties
-            };
             var content = new Utf8JsonRequestContent();
-            content.JsonWriter.WriteObjectValue(model);
+            content.JsonWriter.WriteObjectValue(parameters);
             request.Content = content;
             message.SetProperty("UserAgentOverride", _userAgent);
             return message;
@@ -129,17 +125,21 @@ namespace Azure.ResourceManager.Resources
 
         /// <summary> Creates or updates a resource link between the specified resources. </summary>
         /// <param name="linkId"> The fully qualified ID of the resource link. Use the format, /subscriptions/{subscription-id}/resourceGroups/{resource-group-name}/{provider-namespace}/{resource-type}/{resource-name}/Microsoft.Resources/links/{link-name}. For example, /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myGroup/Microsoft.Web/sites/mySite/Microsoft.Resources/links/myLink. </param>
-        /// <param name="properties"> Properties for resource link. </param>
+        /// <param name="parameters"> Parameters for creating or updating a resource link. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="linkId"/> is null. </exception>
-        public async Task<Response<ResourceLinkData>> CreateOrUpdateAsync(string linkId, ResourceLinkProperties properties = null, CancellationToken cancellationToken = default)
+        /// <exception cref="ArgumentNullException"> <paramref name="linkId"/> or <paramref name="parameters"/> is null. </exception>
+        public async Task<Response<ResourceLinkData>> CreateOrUpdateAsync(string linkId, ResourceLinkData parameters, CancellationToken cancellationToken = default)
         {
             if (linkId == null)
             {
                 throw new ArgumentNullException(nameof(linkId));
             }
+            if (parameters == null)
+            {
+                throw new ArgumentNullException(nameof(parameters));
+            }
 
-            using var message = CreateCreateOrUpdateRequest(linkId, properties);
+            using var message = CreateCreateOrUpdateRequest(linkId, parameters);
             await _pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
             switch (message.Response.Status)
             {
@@ -158,17 +158,21 @@ namespace Azure.ResourceManager.Resources
 
         /// <summary> Creates or updates a resource link between the specified resources. </summary>
         /// <param name="linkId"> The fully qualified ID of the resource link. Use the format, /subscriptions/{subscription-id}/resourceGroups/{resource-group-name}/{provider-namespace}/{resource-type}/{resource-name}/Microsoft.Resources/links/{link-name}. For example, /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myGroup/Microsoft.Web/sites/mySite/Microsoft.Resources/links/myLink. </param>
-        /// <param name="properties"> Properties for resource link. </param>
+        /// <param name="parameters"> Parameters for creating or updating a resource link. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="linkId"/> is null. </exception>
-        public Response<ResourceLinkData> CreateOrUpdate(string linkId, ResourceLinkProperties properties = null, CancellationToken cancellationToken = default)
+        /// <exception cref="ArgumentNullException"> <paramref name="linkId"/> or <paramref name="parameters"/> is null. </exception>
+        public Response<ResourceLinkData> CreateOrUpdate(string linkId, ResourceLinkData parameters, CancellationToken cancellationToken = default)
         {
             if (linkId == null)
             {
                 throw new ArgumentNullException(nameof(linkId));
             }
+            if (parameters == null)
+            {
+                throw new ArgumentNullException(nameof(parameters));
+            }
 
-            using var message = CreateCreateOrUpdateRequest(linkId, properties);
+            using var message = CreateCreateOrUpdateRequest(linkId, parameters);
             _pipeline.Send(message, cancellationToken);
             switch (message.Response.Status)
             {

--- a/sdk/resources/Azure.ResourceManager.Resources/src/Generated/Deployment.cs
+++ b/sdk/resources/Azure.ResourceManager.Resources/src/Generated/Deployment.cs
@@ -361,20 +361,15 @@ namespace Azure.ResourceManager.Resources
         }
 
         /// <summary> Returns changes that will be made by the deployment if executed at the scope of the tenant group. </summary>
-        /// <param name="location"> The location to store the deployment data. </param>
-        /// <param name="properties"> The deployment properties. </param>
+        /// <param name="parameters"> Parameters to validate. </param>
         /// <param name="waitForCompletion"> Waits for the completion of the long running operations. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="location"/> or <paramref name="properties"/> is null. </exception>
-        public async virtual Task<DeploymentWhatIfOperation> WhatIfAsync(bool waitForCompletion, string location, DeploymentWhatIfProperties properties, CancellationToken cancellationToken = default)
+        /// <exception cref="ArgumentNullException"> <paramref name="parameters"/> is null. </exception>
+        public async virtual Task<DeploymentWhatIfOperation> WhatIfAsync(bool waitForCompletion, ScopedDeploymentWhatIf parameters, CancellationToken cancellationToken = default)
         {
-            if (location == null)
+            if (parameters == null)
             {
-                throw new ArgumentNullException(nameof(location));
-            }
-            if (properties == null)
-            {
-                throw new ArgumentNullException(nameof(properties));
+                throw new ArgumentNullException(nameof(parameters));
             }
 
             using var scope = _clientDiagnostics.CreateScope("Deployment.WhatIf");
@@ -383,32 +378,32 @@ namespace Azure.ResourceManager.Resources
             {
                 if (Id.Parent.ResourceType == Tenant.ResourceType)
                 {
-                    var response = await _deploymentsRestClient.WhatIfAtTenantScopeAsync(Id.Name, location, properties, cancellationToken).ConfigureAwait(false);
-                    var operation = new DeploymentWhatIfOperation(_clientDiagnostics, Pipeline, _deploymentsRestClient.CreateWhatIfAtTenantScopeRequest(Id.Name, location, properties).Request, response);
+                    var response = await _deploymentsRestClient.WhatIfAtTenantScopeAsync(Id.Name, parameters, cancellationToken).ConfigureAwait(false);
+                    var operation = new DeploymentWhatIfOperation(_clientDiagnostics, Pipeline, _deploymentsRestClient.CreateWhatIfAtTenantScopeRequest(Id.Name, parameters).Request, response);
                     if (waitForCompletion)
                         await operation.WaitForCompletionAsync(cancellationToken).ConfigureAwait(false);
                     return operation;
                 }
                 else if (Id.Parent.ResourceType == ManagementGroup.ResourceType)
                 {
-                    var response = await _deploymentsRestClient.WhatIfAtManagementGroupScopeAsync(Id.Parent.Name, Id.Name, location, properties, cancellationToken).ConfigureAwait(false);
-                    var operation = new DeploymentWhatIfOperation(_clientDiagnostics, Pipeline, _deploymentsRestClient.CreateWhatIfAtManagementGroupScopeRequest(Id.Parent.Name, Id.Name, location, properties).Request, response);
+                    var response = await _deploymentsRestClient.WhatIfAtManagementGroupScopeAsync(Id.Parent.Name, Id.Name, parameters, cancellationToken).ConfigureAwait(false);
+                    var operation = new DeploymentWhatIfOperation(_clientDiagnostics, Pipeline, _deploymentsRestClient.CreateWhatIfAtManagementGroupScopeRequest(Id.Parent.Name, Id.Name, parameters).Request, response);
                     if (waitForCompletion)
                         await operation.WaitForCompletionAsync(cancellationToken).ConfigureAwait(false);
                     return operation;
                 }
                 else if (Id.Parent.ResourceType == Subscription.ResourceType)
                 {
-                    var response = await _deploymentsRestClient.WhatIfAtSubscriptionScopeAsync(Id.SubscriptionId, Id.Name, properties, location, cancellationToken).ConfigureAwait(false);
-                    var operation = new DeploymentWhatIfOperation(_clientDiagnostics, Pipeline, _deploymentsRestClient.CreateWhatIfAtSubscriptionScopeRequest(Id.SubscriptionId, Id.Name, properties, location).Request, response);
+                    var response = await _deploymentsRestClient.WhatIfAtSubscriptionScopeAsync(Id.SubscriptionId, Id.Name, parameters, cancellationToken).ConfigureAwait(false);
+                    var operation = new DeploymentWhatIfOperation(_clientDiagnostics, Pipeline, _deploymentsRestClient.CreateWhatIfAtSubscriptionScopeRequest(Id.SubscriptionId, Id.Name, parameters).Request, response);
                     if (waitForCompletion)
                         await operation.WaitForCompletionAsync(cancellationToken).ConfigureAwait(false);
                     return operation;
                 }
                 else if (Id.Parent.ResourceType == ResourceGroup.ResourceType)
                 {
-                    var response = await _deploymentsRestClient.WhatIfAsync(Id.SubscriptionId, Id.ResourceGroupName, Id.Name, properties, location, cancellationToken).ConfigureAwait(false);
-                    var operation = new DeploymentWhatIfOperation(_clientDiagnostics, Pipeline, _deploymentsRestClient.CreateWhatIfRequest(Id.SubscriptionId, Id.ResourceGroupName, Id.Name, properties, location).Request, response);
+                    var response = await _deploymentsRestClient.WhatIfAsync(Id.SubscriptionId, Id.ResourceGroupName, Id.Name, parameters, cancellationToken).ConfigureAwait(false);
+                    var operation = new DeploymentWhatIfOperation(_clientDiagnostics, Pipeline, _deploymentsRestClient.CreateWhatIfRequest(Id.SubscriptionId, Id.ResourceGroupName, Id.Name, parameters).Request, response);
                     if (waitForCompletion)
                         await operation.WaitForCompletionAsync(cancellationToken).ConfigureAwait(false);
                     return operation;
@@ -426,20 +421,15 @@ namespace Azure.ResourceManager.Resources
         }
 
         /// <summary> Returns changes that will be made by the deployment if executed at the scope of the tenant group. </summary>
-        /// <param name="location"> The location to store the deployment data. </param>
-        /// <param name="properties"> The deployment properties. </param>
+        /// <param name="parameters"> Parameters to validate. </param>
         /// <param name="waitForCompletion"> Waits for the completion of the long running operations. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="location"/> or <paramref name="properties"/> is null. </exception>
-        public virtual DeploymentWhatIfOperation WhatIf(bool waitForCompletion, string location, DeploymentWhatIfProperties properties, CancellationToken cancellationToken = default)
+        /// <exception cref="ArgumentNullException"> <paramref name="parameters"/> is null. </exception>
+        public virtual DeploymentWhatIfOperation WhatIf(bool waitForCompletion, ScopedDeploymentWhatIf parameters, CancellationToken cancellationToken = default)
         {
-            if (location == null)
+            if (parameters == null)
             {
-                throw new ArgumentNullException(nameof(location));
-            }
-            if (properties == null)
-            {
-                throw new ArgumentNullException(nameof(properties));
+                throw new ArgumentNullException(nameof(parameters));
             }
 
             using var scope = _clientDiagnostics.CreateScope("Deployment.WhatIf");
@@ -448,32 +438,32 @@ namespace Azure.ResourceManager.Resources
             {
                 if (Id.Parent.ResourceType == Tenant.ResourceType)
                 {
-                    var response = _deploymentsRestClient.WhatIfAtTenantScope(Id.Name, location, properties, cancellationToken);
-                    var operation = new DeploymentWhatIfOperation(_clientDiagnostics, Pipeline, _deploymentsRestClient.CreateWhatIfAtTenantScopeRequest(Id.Name, location, properties).Request, response);
+                    var response = _deploymentsRestClient.WhatIfAtTenantScope(Id.Name, parameters, cancellationToken);
+                    var operation = new DeploymentWhatIfOperation(_clientDiagnostics, Pipeline, _deploymentsRestClient.CreateWhatIfAtTenantScopeRequest(Id.Name, parameters).Request, response);
                     if (waitForCompletion)
                         operation.WaitForCompletion(cancellationToken);
                     return operation;
                 }
                 else if (Id.Parent.ResourceType == ManagementGroup.ResourceType)
                 {
-                    var response = _deploymentsRestClient.WhatIfAtManagementGroupScope(Id.Parent.Name, Id.Name, location, properties, cancellationToken);
-                    var operation = new DeploymentWhatIfOperation(_clientDiagnostics, Pipeline, _deploymentsRestClient.CreateWhatIfAtManagementGroupScopeRequest(Id.Parent.Name, Id.Name, location, properties).Request, response);
+                    var response = _deploymentsRestClient.WhatIfAtManagementGroupScope(Id.Parent.Name, Id.Name, parameters, cancellationToken);
+                    var operation = new DeploymentWhatIfOperation(_clientDiagnostics, Pipeline, _deploymentsRestClient.CreateWhatIfAtManagementGroupScopeRequest(Id.Parent.Name, Id.Name, parameters).Request, response);
                     if (waitForCompletion)
                         operation.WaitForCompletion(cancellationToken);
                     return operation;
                 }
                 else if (Id.Parent.ResourceType == Subscription.ResourceType)
                 {
-                    var response = _deploymentsRestClient.WhatIfAtSubscriptionScope(Id.SubscriptionId, Id.Name, properties, location, cancellationToken);
-                    var operation = new DeploymentWhatIfOperation(_clientDiagnostics, Pipeline, _deploymentsRestClient.CreateWhatIfAtSubscriptionScopeRequest(Id.SubscriptionId, Id.Name, properties, location).Request, response);
+                    var response = _deploymentsRestClient.WhatIfAtSubscriptionScope(Id.SubscriptionId, Id.Name, parameters, cancellationToken);
+                    var operation = new DeploymentWhatIfOperation(_clientDiagnostics, Pipeline, _deploymentsRestClient.CreateWhatIfAtSubscriptionScopeRequest(Id.SubscriptionId, Id.Name, parameters).Request, response);
                     if (waitForCompletion)
                         operation.WaitForCompletion(cancellationToken);
                     return operation;
                 }
                 else if (Id.Parent.ResourceType == ResourceGroup.ResourceType)
                 {
-                    var response = _deploymentsRestClient.WhatIf(Id.SubscriptionId, Id.ResourceGroupName, Id.Name, properties, location, cancellationToken);
-                    var operation = new DeploymentWhatIfOperation(_clientDiagnostics, Pipeline, _deploymentsRestClient.CreateWhatIfRequest(Id.SubscriptionId, Id.ResourceGroupName, Id.Name, properties, location).Request, response);
+                    var response = _deploymentsRestClient.WhatIf(Id.SubscriptionId, Id.ResourceGroupName, Id.Name, parameters, cancellationToken);
+                    var operation = new DeploymentWhatIfOperation(_clientDiagnostics, Pipeline, _deploymentsRestClient.CreateWhatIfRequest(Id.SubscriptionId, Id.ResourceGroupName, Id.Name, parameters).Request, response);
                     if (waitForCompletion)
                         operation.WaitForCompletion(cancellationToken);
                     return operation;

--- a/sdk/resources/Azure.ResourceManager.Resources/src/Generated/DeploymentScript.cs
+++ b/sdk/resources/Azure.ResourceManager.Resources/src/Generated/DeploymentScript.cs
@@ -226,15 +226,15 @@ namespace Azure.ResourceManager.Resources
         }
 
         /// <summary> Updates deployment script tags with specified values. </summary>
-        /// <param name="tags"> Resource tags to be updated. </param>
+        /// <param name="deploymentScript"> Deployment script resource with the tags to be updated. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public async virtual Task<Response<DeploymentScript>> UpdateAsync(IDictionary<string, string> tags = null, CancellationToken cancellationToken = default)
+        public async virtual Task<Response<DeploymentScript>> UpdateAsync(DeploymentScriptUpdateParameter deploymentScript = null, CancellationToken cancellationToken = default)
         {
             using var scope = _clientDiagnostics.CreateScope("DeploymentScript.Update");
             scope.Start();
             try
             {
-                var response = await _deploymentScriptsRestClient.UpdateAsync(Id.SubscriptionId, Id.ResourceGroupName, Id.Name, tags, cancellationToken).ConfigureAwait(false);
+                var response = await _deploymentScriptsRestClient.UpdateAsync(Id.SubscriptionId, Id.ResourceGroupName, Id.Name, deploymentScript, cancellationToken).ConfigureAwait(false);
                 return Response.FromValue(new DeploymentScript(this, response.Value), response.GetRawResponse());
             }
             catch (Exception e)
@@ -245,15 +245,15 @@ namespace Azure.ResourceManager.Resources
         }
 
         /// <summary> Updates deployment script tags with specified values. </summary>
-        /// <param name="tags"> Resource tags to be updated. </param>
+        /// <param name="deploymentScript"> Deployment script resource with the tags to be updated. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public virtual Response<DeploymentScript> Update(IDictionary<string, string> tags = null, CancellationToken cancellationToken = default)
+        public virtual Response<DeploymentScript> Update(DeploymentScriptUpdateParameter deploymentScript = null, CancellationToken cancellationToken = default)
         {
             using var scope = _clientDiagnostics.CreateScope("DeploymentScript.Update");
             scope.Start();
             try
             {
-                var response = _deploymentScriptsRestClient.Update(Id.SubscriptionId, Id.ResourceGroupName, Id.Name, tags, cancellationToken);
+                var response = _deploymentScriptsRestClient.Update(Id.SubscriptionId, Id.ResourceGroupName, Id.Name, deploymentScript, cancellationToken);
                 return Response.FromValue(new DeploymentScript(this, response.Value), response.GetRawResponse());
             }
             catch (Exception e)

--- a/sdk/resources/Azure.ResourceManager.Resources/src/Generated/JitRequestDefinition.cs
+++ b/sdk/resources/Azure.ResourceManager.Resources/src/Generated/JitRequestDefinition.cs
@@ -398,15 +398,21 @@ namespace Azure.ResourceManager.Resources
         }
 
         /// <summary> Updates the JIT request. </summary>
-        /// <param name="tags"> Jit request tags. </param>
+        /// <param name="parameters"> Parameters supplied to the update JIT request. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public async virtual Task<Response<JitRequestDefinition>> UpdateAsync(IDictionary<string, string> tags = null, CancellationToken cancellationToken = default)
+        /// <exception cref="ArgumentNullException"> <paramref name="parameters"/> is null. </exception>
+        public async virtual Task<Response<JitRequestDefinition>> UpdateAsync(JitRequestPatchable parameters, CancellationToken cancellationToken = default)
         {
+            if (parameters == null)
+            {
+                throw new ArgumentNullException(nameof(parameters));
+            }
+
             using var scope = _clientDiagnostics.CreateScope("JitRequestDefinition.Update");
             scope.Start();
             try
             {
-                var response = await _jitRequestsRestClient.UpdateAsync(Id.SubscriptionId, Id.ResourceGroupName, Id.Name, tags, cancellationToken).ConfigureAwait(false);
+                var response = await _jitRequestsRestClient.UpdateAsync(Id.SubscriptionId, Id.ResourceGroupName, Id.Name, parameters, cancellationToken).ConfigureAwait(false);
                 return Response.FromValue(new JitRequestDefinition(this, response.Value), response.GetRawResponse());
             }
             catch (Exception e)
@@ -417,15 +423,21 @@ namespace Azure.ResourceManager.Resources
         }
 
         /// <summary> Updates the JIT request. </summary>
-        /// <param name="tags"> Jit request tags. </param>
+        /// <param name="parameters"> Parameters supplied to the update JIT request. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public virtual Response<JitRequestDefinition> Update(IDictionary<string, string> tags = null, CancellationToken cancellationToken = default)
+        /// <exception cref="ArgumentNullException"> <paramref name="parameters"/> is null. </exception>
+        public virtual Response<JitRequestDefinition> Update(JitRequestPatchable parameters, CancellationToken cancellationToken = default)
         {
+            if (parameters == null)
+            {
+                throw new ArgumentNullException(nameof(parameters));
+            }
+
             using var scope = _clientDiagnostics.CreateScope("JitRequestDefinition.Update");
             scope.Start();
             try
             {
-                var response = _jitRequestsRestClient.Update(Id.SubscriptionId, Id.ResourceGroupName, Id.Name, tags, cancellationToken);
+                var response = _jitRequestsRestClient.Update(Id.SubscriptionId, Id.ResourceGroupName, Id.Name, parameters, cancellationToken);
                 return Response.FromValue(new JitRequestDefinition(this, response.Value), response.GetRawResponse());
             }
             catch (Exception e)

--- a/sdk/resources/Azure.ResourceManager.Resources/src/Generated/Models/DeploymentWhatIf.Serialization.cs
+++ b/sdk/resources/Azure.ResourceManager.Resources/src/Generated/Models/DeploymentWhatIf.Serialization.cs
@@ -10,7 +10,7 @@ using Azure.Core;
 
 namespace Azure.ResourceManager.Resources.Models
 {
-    internal partial class DeploymentWhatIf : IUtf8JsonSerializable
+    public partial class DeploymentWhatIf : IUtf8JsonSerializable
     {
         void IUtf8JsonSerializable.Write(Utf8JsonWriter writer)
         {

--- a/sdk/resources/Azure.ResourceManager.Resources/src/Generated/Models/DeploymentWhatIf.cs
+++ b/sdk/resources/Azure.ResourceManager.Resources/src/Generated/Models/DeploymentWhatIf.cs
@@ -10,7 +10,7 @@ using System;
 namespace Azure.ResourceManager.Resources.Models
 {
     /// <summary> Deployment What-if operation parameters. </summary>
-    internal partial class DeploymentWhatIf
+    public partial class DeploymentWhatIf
     {
         /// <summary> Initializes a new instance of DeploymentWhatIf. </summary>
         /// <param name="properties"> The deployment properties. </param>

--- a/sdk/resources/Azure.ResourceManager.Resources/src/Generated/Models/JitRequestPatchable.Serialization.cs
+++ b/sdk/resources/Azure.ResourceManager.Resources/src/Generated/Models/JitRequestPatchable.Serialization.cs
@@ -10,7 +10,7 @@ using Azure.Core;
 
 namespace Azure.ResourceManager.Resources.Models
 {
-    internal partial class JitRequestPatchable : IUtf8JsonSerializable
+    public partial class JitRequestPatchable : IUtf8JsonSerializable
     {
         void IUtf8JsonSerializable.Write(Utf8JsonWriter writer)
         {

--- a/sdk/resources/Azure.ResourceManager.Resources/src/Generated/Models/JitRequestPatchable.cs
+++ b/sdk/resources/Azure.ResourceManager.Resources/src/Generated/Models/JitRequestPatchable.cs
@@ -11,7 +11,7 @@ using Azure.Core;
 namespace Azure.ResourceManager.Resources.Models
 {
     /// <summary> Information about JIT request. </summary>
-    internal partial class JitRequestPatchable
+    public partial class JitRequestPatchable
     {
         /// <summary> Initializes a new instance of JitRequestPatchable. </summary>
         public JitRequestPatchable()

--- a/sdk/resources/Azure.ResourceManager.Resources/src/Generated/Models/ScopedDeploymentWhatIf.Serialization.cs
+++ b/sdk/resources/Azure.ResourceManager.Resources/src/Generated/Models/ScopedDeploymentWhatIf.Serialization.cs
@@ -10,7 +10,7 @@ using Azure.Core;
 
 namespace Azure.ResourceManager.Resources.Models
 {
-    internal partial class ScopedDeploymentWhatIf : IUtf8JsonSerializable
+    public partial class ScopedDeploymentWhatIf : IUtf8JsonSerializable
     {
         void IUtf8JsonSerializable.Write(Utf8JsonWriter writer)
         {

--- a/sdk/resources/Azure.ResourceManager.Resources/src/Generated/Models/ScopedDeploymentWhatIf.cs
+++ b/sdk/resources/Azure.ResourceManager.Resources/src/Generated/Models/ScopedDeploymentWhatIf.cs
@@ -10,7 +10,7 @@ using System;
 namespace Azure.ResourceManager.Resources.Models
 {
     /// <summary> Deployment What-if operation parameters. </summary>
-    internal partial class ScopedDeploymentWhatIf
+    public partial class ScopedDeploymentWhatIf
     {
         /// <summary> Initializes a new instance of ScopedDeploymentWhatIf. </summary>
         /// <param name="location"> The location to store the deployment data. </param>

--- a/sdk/resources/Azure.ResourceManager.Resources/src/Generated/RestOperations/DeploymentScriptsRestOperations.cs
+++ b/sdk/resources/Azure.ResourceManager.Resources/src/Generated/RestOperations/DeploymentScriptsRestOperations.cs
@@ -6,7 +6,6 @@
 #nullable disable
 
 using System;
-using System.Collections.Generic;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -143,7 +142,7 @@ namespace Azure.ResourceManager.Resources
             }
         }
 
-        internal Azure.Core.HttpMessage CreateUpdateRequest(string subscriptionId, string resourceGroupName, string scriptName, IDictionary<string, string> tags)
+        internal Azure.Core.HttpMessage CreateUpdateRequest(string subscriptionId, string resourceGroupName, string scriptName, DeploymentScriptUpdateParameter deploymentScript)
         {
             var message = _pipeline.CreateMessage();
             var request = message.Request;
@@ -159,19 +158,13 @@ namespace Azure.ResourceManager.Resources
             uri.AppendQuery("api-version", apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
-            request.Headers.Add("Content-Type", "application/json");
-            DeploymentScriptUpdateParameter deploymentScriptUpdateParameter = new DeploymentScriptUpdateParameter();
-            if (tags != null)
+            if (deploymentScript != null)
             {
-                foreach (var value in tags)
-                {
-                    deploymentScriptUpdateParameter.Tags.Add(value);
-                }
+                request.Headers.Add("Content-Type", "application/json");
+                var content = new Utf8JsonRequestContent();
+                content.JsonWriter.WriteObjectValue(deploymentScript);
+                request.Content = content;
             }
-            var model = deploymentScriptUpdateParameter;
-            var content = new Utf8JsonRequestContent();
-            content.JsonWriter.WriteObjectValue(model);
-            request.Content = content;
             message.SetProperty("UserAgentOverride", _userAgent);
             return message;
         }
@@ -180,10 +173,10 @@ namespace Azure.ResourceManager.Resources
         /// <param name="subscriptionId"> The Microsoft Azure subscription ID. </param>
         /// <param name="resourceGroupName"> The name of the resource group. The name is case insensitive. </param>
         /// <param name="scriptName"> Name of the deployment script. </param>
-        /// <param name="tags"> Resource tags to be updated. </param>
+        /// <param name="deploymentScript"> Deployment script resource with the tags to be updated. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="subscriptionId"/>, <paramref name="resourceGroupName"/>, or <paramref name="scriptName"/> is null. </exception>
-        public async Task<Response<DeploymentScriptData>> UpdateAsync(string subscriptionId, string resourceGroupName, string scriptName, IDictionary<string, string> tags = null, CancellationToken cancellationToken = default)
+        public async Task<Response<DeploymentScriptData>> UpdateAsync(string subscriptionId, string resourceGroupName, string scriptName, DeploymentScriptUpdateParameter deploymentScript = null, CancellationToken cancellationToken = default)
         {
             if (subscriptionId == null)
             {
@@ -198,7 +191,7 @@ namespace Azure.ResourceManager.Resources
                 throw new ArgumentNullException(nameof(scriptName));
             }
 
-            using var message = CreateUpdateRequest(subscriptionId, resourceGroupName, scriptName, tags);
+            using var message = CreateUpdateRequest(subscriptionId, resourceGroupName, scriptName, deploymentScript);
             await _pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
             switch (message.Response.Status)
             {
@@ -218,10 +211,10 @@ namespace Azure.ResourceManager.Resources
         /// <param name="subscriptionId"> The Microsoft Azure subscription ID. </param>
         /// <param name="resourceGroupName"> The name of the resource group. The name is case insensitive. </param>
         /// <param name="scriptName"> Name of the deployment script. </param>
-        /// <param name="tags"> Resource tags to be updated. </param>
+        /// <param name="deploymentScript"> Deployment script resource with the tags to be updated. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="subscriptionId"/>, <paramref name="resourceGroupName"/>, or <paramref name="scriptName"/> is null. </exception>
-        public Response<DeploymentScriptData> Update(string subscriptionId, string resourceGroupName, string scriptName, IDictionary<string, string> tags = null, CancellationToken cancellationToken = default)
+        public Response<DeploymentScriptData> Update(string subscriptionId, string resourceGroupName, string scriptName, DeploymentScriptUpdateParameter deploymentScript = null, CancellationToken cancellationToken = default)
         {
             if (subscriptionId == null)
             {
@@ -236,7 +229,7 @@ namespace Azure.ResourceManager.Resources
                 throw new ArgumentNullException(nameof(scriptName));
             }
 
-            using var message = CreateUpdateRequest(subscriptionId, resourceGroupName, scriptName, tags);
+            using var message = CreateUpdateRequest(subscriptionId, resourceGroupName, scriptName, deploymentScript);
             _pipeline.Send(message, cancellationToken);
             switch (message.Response.Status)
             {

--- a/sdk/resources/Azure.ResourceManager.Resources/src/Generated/RestOperations/DeploymentsRestOperations.cs
+++ b/sdk/resources/Azure.ResourceManager.Resources/src/Generated/RestOperations/DeploymentsRestOperations.cs
@@ -694,7 +694,7 @@ namespace Azure.ResourceManager.Resources
             }
         }
 
-        internal Azure.Core.HttpMessage CreateWhatIfAtTenantScopeRequest(string deploymentName, string location, DeploymentWhatIfProperties properties)
+        internal Azure.Core.HttpMessage CreateWhatIfAtTenantScopeRequest(string deploymentName, ScopedDeploymentWhatIf parameters)
         {
             var message = _pipeline.CreateMessage();
             var request = message.Request;
@@ -708,9 +708,8 @@ namespace Azure.ResourceManager.Resources
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             request.Headers.Add("Content-Type", "application/json");
-            var model = new ScopedDeploymentWhatIf(location, properties);
             var content = new Utf8JsonRequestContent();
-            content.JsonWriter.WriteObjectValue(model);
+            content.JsonWriter.WriteObjectValue(parameters);
             request.Content = content;
             message.SetProperty("UserAgentOverride", _userAgent);
             return message;
@@ -718,26 +717,21 @@ namespace Azure.ResourceManager.Resources
 
         /// <summary> Returns changes that will be made by the deployment if executed at the scope of the tenant group. </summary>
         /// <param name="deploymentName"> The name of the deployment. </param>
-        /// <param name="location"> The location to store the deployment data. </param>
-        /// <param name="properties"> The deployment properties. </param>
+        /// <param name="parameters"> Parameters to validate. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="deploymentName"/>, <paramref name="location"/>, or <paramref name="properties"/> is null. </exception>
-        public async Task<Response> WhatIfAtTenantScopeAsync(string deploymentName, string location, DeploymentWhatIfProperties properties, CancellationToken cancellationToken = default)
+        /// <exception cref="ArgumentNullException"> <paramref name="deploymentName"/> or <paramref name="parameters"/> is null. </exception>
+        public async Task<Response> WhatIfAtTenantScopeAsync(string deploymentName, ScopedDeploymentWhatIf parameters, CancellationToken cancellationToken = default)
         {
             if (deploymentName == null)
             {
                 throw new ArgumentNullException(nameof(deploymentName));
             }
-            if (location == null)
+            if (parameters == null)
             {
-                throw new ArgumentNullException(nameof(location));
-            }
-            if (properties == null)
-            {
-                throw new ArgumentNullException(nameof(properties));
+                throw new ArgumentNullException(nameof(parameters));
             }
 
-            using var message = CreateWhatIfAtTenantScopeRequest(deploymentName, location, properties);
+            using var message = CreateWhatIfAtTenantScopeRequest(deploymentName, parameters);
             await _pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
             switch (message.Response.Status)
             {
@@ -751,26 +745,21 @@ namespace Azure.ResourceManager.Resources
 
         /// <summary> Returns changes that will be made by the deployment if executed at the scope of the tenant group. </summary>
         /// <param name="deploymentName"> The name of the deployment. </param>
-        /// <param name="location"> The location to store the deployment data. </param>
-        /// <param name="properties"> The deployment properties. </param>
+        /// <param name="parameters"> Parameters to validate. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="deploymentName"/>, <paramref name="location"/>, or <paramref name="properties"/> is null. </exception>
-        public Response WhatIfAtTenantScope(string deploymentName, string location, DeploymentWhatIfProperties properties, CancellationToken cancellationToken = default)
+        /// <exception cref="ArgumentNullException"> <paramref name="deploymentName"/> or <paramref name="parameters"/> is null. </exception>
+        public Response WhatIfAtTenantScope(string deploymentName, ScopedDeploymentWhatIf parameters, CancellationToken cancellationToken = default)
         {
             if (deploymentName == null)
             {
                 throw new ArgumentNullException(nameof(deploymentName));
             }
-            if (location == null)
+            if (parameters == null)
             {
-                throw new ArgumentNullException(nameof(location));
-            }
-            if (properties == null)
-            {
-                throw new ArgumentNullException(nameof(properties));
+                throw new ArgumentNullException(nameof(parameters));
             }
 
-            using var message = CreateWhatIfAtTenantScopeRequest(deploymentName, location, properties);
+            using var message = CreateWhatIfAtTenantScopeRequest(deploymentName, parameters);
             _pipeline.Send(message, cancellationToken);
             switch (message.Response.Status)
             {
@@ -782,7 +771,7 @@ namespace Azure.ResourceManager.Resources
             }
         }
 
-        internal Azure.Core.HttpMessage CreateWhatIfAtManagementGroupScopeRequest(string groupId, string deploymentName, string location, DeploymentWhatIfProperties properties)
+        internal Azure.Core.HttpMessage CreateWhatIfAtManagementGroupScopeRequest(string groupId, string deploymentName, ScopedDeploymentWhatIf parameters)
         {
             var message = _pipeline.CreateMessage();
             var request = message.Request;
@@ -798,9 +787,8 @@ namespace Azure.ResourceManager.Resources
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             request.Headers.Add("Content-Type", "application/json");
-            var model = new ScopedDeploymentWhatIf(location, properties);
             var content = new Utf8JsonRequestContent();
-            content.JsonWriter.WriteObjectValue(model);
+            content.JsonWriter.WriteObjectValue(parameters);
             request.Content = content;
             message.SetProperty("UserAgentOverride", _userAgent);
             return message;
@@ -809,11 +797,10 @@ namespace Azure.ResourceManager.Resources
         /// <summary> Returns changes that will be made by the deployment if executed at the scope of the management group. </summary>
         /// <param name="groupId"> The management group ID. </param>
         /// <param name="deploymentName"> The name of the deployment. </param>
-        /// <param name="location"> The location to store the deployment data. </param>
-        /// <param name="properties"> The deployment properties. </param>
+        /// <param name="parameters"> Parameters to validate. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="groupId"/>, <paramref name="deploymentName"/>, <paramref name="location"/>, or <paramref name="properties"/> is null. </exception>
-        public async Task<Response> WhatIfAtManagementGroupScopeAsync(string groupId, string deploymentName, string location, DeploymentWhatIfProperties properties, CancellationToken cancellationToken = default)
+        /// <exception cref="ArgumentNullException"> <paramref name="groupId"/>, <paramref name="deploymentName"/>, or <paramref name="parameters"/> is null. </exception>
+        public async Task<Response> WhatIfAtManagementGroupScopeAsync(string groupId, string deploymentName, ScopedDeploymentWhatIf parameters, CancellationToken cancellationToken = default)
         {
             if (groupId == null)
             {
@@ -823,16 +810,12 @@ namespace Azure.ResourceManager.Resources
             {
                 throw new ArgumentNullException(nameof(deploymentName));
             }
-            if (location == null)
+            if (parameters == null)
             {
-                throw new ArgumentNullException(nameof(location));
-            }
-            if (properties == null)
-            {
-                throw new ArgumentNullException(nameof(properties));
+                throw new ArgumentNullException(nameof(parameters));
             }
 
-            using var message = CreateWhatIfAtManagementGroupScopeRequest(groupId, deploymentName, location, properties);
+            using var message = CreateWhatIfAtManagementGroupScopeRequest(groupId, deploymentName, parameters);
             await _pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
             switch (message.Response.Status)
             {
@@ -847,11 +830,10 @@ namespace Azure.ResourceManager.Resources
         /// <summary> Returns changes that will be made by the deployment if executed at the scope of the management group. </summary>
         /// <param name="groupId"> The management group ID. </param>
         /// <param name="deploymentName"> The name of the deployment. </param>
-        /// <param name="location"> The location to store the deployment data. </param>
-        /// <param name="properties"> The deployment properties. </param>
+        /// <param name="parameters"> Parameters to validate. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="groupId"/>, <paramref name="deploymentName"/>, <paramref name="location"/>, or <paramref name="properties"/> is null. </exception>
-        public Response WhatIfAtManagementGroupScope(string groupId, string deploymentName, string location, DeploymentWhatIfProperties properties, CancellationToken cancellationToken = default)
+        /// <exception cref="ArgumentNullException"> <paramref name="groupId"/>, <paramref name="deploymentName"/>, or <paramref name="parameters"/> is null. </exception>
+        public Response WhatIfAtManagementGroupScope(string groupId, string deploymentName, ScopedDeploymentWhatIf parameters, CancellationToken cancellationToken = default)
         {
             if (groupId == null)
             {
@@ -861,16 +843,12 @@ namespace Azure.ResourceManager.Resources
             {
                 throw new ArgumentNullException(nameof(deploymentName));
             }
-            if (location == null)
+            if (parameters == null)
             {
-                throw new ArgumentNullException(nameof(location));
-            }
-            if (properties == null)
-            {
-                throw new ArgumentNullException(nameof(properties));
+                throw new ArgumentNullException(nameof(parameters));
             }
 
-            using var message = CreateWhatIfAtManagementGroupScopeRequest(groupId, deploymentName, location, properties);
+            using var message = CreateWhatIfAtManagementGroupScopeRequest(groupId, deploymentName, parameters);
             _pipeline.Send(message, cancellationToken);
             switch (message.Response.Status)
             {
@@ -882,7 +860,7 @@ namespace Azure.ResourceManager.Resources
             }
         }
 
-        internal Azure.Core.HttpMessage CreateWhatIfAtSubscriptionScopeRequest(string subscriptionId, string deploymentName, DeploymentWhatIfProperties properties, string location)
+        internal Azure.Core.HttpMessage CreateWhatIfAtSubscriptionScopeRequest(string subscriptionId, string deploymentName, DeploymentWhatIf parameters)
         {
             var message = _pipeline.CreateMessage();
             var request = message.Request;
@@ -898,12 +876,8 @@ namespace Azure.ResourceManager.Resources
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             request.Headers.Add("Content-Type", "application/json");
-            var model = new DeploymentWhatIf(properties)
-            {
-                Location = location
-            };
             var content = new Utf8JsonRequestContent();
-            content.JsonWriter.WriteObjectValue(model);
+            content.JsonWriter.WriteObjectValue(parameters);
             request.Content = content;
             message.SetProperty("UserAgentOverride", _userAgent);
             return message;
@@ -912,11 +886,10 @@ namespace Azure.ResourceManager.Resources
         /// <summary> Returns changes that will be made by the deployment if executed at the scope of the subscription. </summary>
         /// <param name="subscriptionId"> The Microsoft Azure subscription ID. </param>
         /// <param name="deploymentName"> The name of the deployment. </param>
-        /// <param name="properties"> The deployment properties. </param>
-        /// <param name="location"> The location to store the deployment data. </param>
+        /// <param name="parameters"> Parameters to What If. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="subscriptionId"/>, <paramref name="deploymentName"/>, or <paramref name="properties"/> is null. </exception>
-        public async Task<Response> WhatIfAtSubscriptionScopeAsync(string subscriptionId, string deploymentName, DeploymentWhatIfProperties properties, string location = null, CancellationToken cancellationToken = default)
+        /// <exception cref="ArgumentNullException"> <paramref name="subscriptionId"/>, <paramref name="deploymentName"/>, or <paramref name="parameters"/> is null. </exception>
+        public async Task<Response> WhatIfAtSubscriptionScopeAsync(string subscriptionId, string deploymentName, DeploymentWhatIf parameters, CancellationToken cancellationToken = default)
         {
             if (subscriptionId == null)
             {
@@ -926,12 +899,12 @@ namespace Azure.ResourceManager.Resources
             {
                 throw new ArgumentNullException(nameof(deploymentName));
             }
-            if (properties == null)
+            if (parameters == null)
             {
-                throw new ArgumentNullException(nameof(properties));
+                throw new ArgumentNullException(nameof(parameters));
             }
 
-            using var message = CreateWhatIfAtSubscriptionScopeRequest(subscriptionId, deploymentName, properties, location);
+            using var message = CreateWhatIfAtSubscriptionScopeRequest(subscriptionId, deploymentName, parameters);
             await _pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
             switch (message.Response.Status)
             {
@@ -946,11 +919,10 @@ namespace Azure.ResourceManager.Resources
         /// <summary> Returns changes that will be made by the deployment if executed at the scope of the subscription. </summary>
         /// <param name="subscriptionId"> The Microsoft Azure subscription ID. </param>
         /// <param name="deploymentName"> The name of the deployment. </param>
-        /// <param name="properties"> The deployment properties. </param>
-        /// <param name="location"> The location to store the deployment data. </param>
+        /// <param name="parameters"> Parameters to What If. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="subscriptionId"/>, <paramref name="deploymentName"/>, or <paramref name="properties"/> is null. </exception>
-        public Response WhatIfAtSubscriptionScope(string subscriptionId, string deploymentName, DeploymentWhatIfProperties properties, string location = null, CancellationToken cancellationToken = default)
+        /// <exception cref="ArgumentNullException"> <paramref name="subscriptionId"/>, <paramref name="deploymentName"/>, or <paramref name="parameters"/> is null. </exception>
+        public Response WhatIfAtSubscriptionScope(string subscriptionId, string deploymentName, DeploymentWhatIf parameters, CancellationToken cancellationToken = default)
         {
             if (subscriptionId == null)
             {
@@ -960,12 +932,12 @@ namespace Azure.ResourceManager.Resources
             {
                 throw new ArgumentNullException(nameof(deploymentName));
             }
-            if (properties == null)
+            if (parameters == null)
             {
-                throw new ArgumentNullException(nameof(properties));
+                throw new ArgumentNullException(nameof(parameters));
             }
 
-            using var message = CreateWhatIfAtSubscriptionScopeRequest(subscriptionId, deploymentName, properties, location);
+            using var message = CreateWhatIfAtSubscriptionScopeRequest(subscriptionId, deploymentName, parameters);
             _pipeline.Send(message, cancellationToken);
             switch (message.Response.Status)
             {
@@ -977,7 +949,7 @@ namespace Azure.ResourceManager.Resources
             }
         }
 
-        internal Azure.Core.HttpMessage CreateWhatIfRequest(string subscriptionId, string resourceGroupName, string deploymentName, DeploymentWhatIfProperties properties, string location)
+        internal Azure.Core.HttpMessage CreateWhatIfRequest(string subscriptionId, string resourceGroupName, string deploymentName, DeploymentWhatIf parameters)
         {
             var message = _pipeline.CreateMessage();
             var request = message.Request;
@@ -995,12 +967,8 @@ namespace Azure.ResourceManager.Resources
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             request.Headers.Add("Content-Type", "application/json");
-            var model = new DeploymentWhatIf(properties)
-            {
-                Location = location
-            };
             var content = new Utf8JsonRequestContent();
-            content.JsonWriter.WriteObjectValue(model);
+            content.JsonWriter.WriteObjectValue(parameters);
             request.Content = content;
             message.SetProperty("UserAgentOverride", _userAgent);
             return message;
@@ -1010,11 +978,10 @@ namespace Azure.ResourceManager.Resources
         /// <param name="subscriptionId"> The Microsoft Azure subscription ID. </param>
         /// <param name="resourceGroupName"> The name of the resource group the template will be deployed to. The name is case insensitive. </param>
         /// <param name="deploymentName"> The name of the deployment. </param>
-        /// <param name="properties"> The deployment properties. </param>
-        /// <param name="location"> The location to store the deployment data. </param>
+        /// <param name="parameters"> Parameters to validate. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="subscriptionId"/>, <paramref name="resourceGroupName"/>, <paramref name="deploymentName"/>, or <paramref name="properties"/> is null. </exception>
-        public async Task<Response> WhatIfAsync(string subscriptionId, string resourceGroupName, string deploymentName, DeploymentWhatIfProperties properties, string location = null, CancellationToken cancellationToken = default)
+        /// <exception cref="ArgumentNullException"> <paramref name="subscriptionId"/>, <paramref name="resourceGroupName"/>, <paramref name="deploymentName"/>, or <paramref name="parameters"/> is null. </exception>
+        public async Task<Response> WhatIfAsync(string subscriptionId, string resourceGroupName, string deploymentName, DeploymentWhatIf parameters, CancellationToken cancellationToken = default)
         {
             if (subscriptionId == null)
             {
@@ -1028,12 +995,12 @@ namespace Azure.ResourceManager.Resources
             {
                 throw new ArgumentNullException(nameof(deploymentName));
             }
-            if (properties == null)
+            if (parameters == null)
             {
-                throw new ArgumentNullException(nameof(properties));
+                throw new ArgumentNullException(nameof(parameters));
             }
 
-            using var message = CreateWhatIfRequest(subscriptionId, resourceGroupName, deploymentName, properties, location);
+            using var message = CreateWhatIfRequest(subscriptionId, resourceGroupName, deploymentName, parameters);
             await _pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
             switch (message.Response.Status)
             {
@@ -1049,11 +1016,10 @@ namespace Azure.ResourceManager.Resources
         /// <param name="subscriptionId"> The Microsoft Azure subscription ID. </param>
         /// <param name="resourceGroupName"> The name of the resource group the template will be deployed to. The name is case insensitive. </param>
         /// <param name="deploymentName"> The name of the deployment. </param>
-        /// <param name="properties"> The deployment properties. </param>
-        /// <param name="location"> The location to store the deployment data. </param>
+        /// <param name="parameters"> Parameters to validate. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="subscriptionId"/>, <paramref name="resourceGroupName"/>, <paramref name="deploymentName"/>, or <paramref name="properties"/> is null. </exception>
-        public Response WhatIf(string subscriptionId, string resourceGroupName, string deploymentName, DeploymentWhatIfProperties properties, string location = null, CancellationToken cancellationToken = default)
+        /// <exception cref="ArgumentNullException"> <paramref name="subscriptionId"/>, <paramref name="resourceGroupName"/>, <paramref name="deploymentName"/>, or <paramref name="parameters"/> is null. </exception>
+        public Response WhatIf(string subscriptionId, string resourceGroupName, string deploymentName, DeploymentWhatIf parameters, CancellationToken cancellationToken = default)
         {
             if (subscriptionId == null)
             {
@@ -1067,12 +1033,12 @@ namespace Azure.ResourceManager.Resources
             {
                 throw new ArgumentNullException(nameof(deploymentName));
             }
-            if (properties == null)
+            if (parameters == null)
             {
-                throw new ArgumentNullException(nameof(properties));
+                throw new ArgumentNullException(nameof(parameters));
             }
 
-            using var message = CreateWhatIfRequest(subscriptionId, resourceGroupName, deploymentName, properties, location);
+            using var message = CreateWhatIfRequest(subscriptionId, resourceGroupName, deploymentName, parameters);
             _pipeline.Send(message, cancellationToken);
             switch (message.Response.Status)
             {

--- a/sdk/resources/Azure.ResourceManager.Resources/src/Generated/RestOperations/JitRequestsRestOperations.cs
+++ b/sdk/resources/Azure.ResourceManager.Resources/src/Generated/RestOperations/JitRequestsRestOperations.cs
@@ -6,7 +6,6 @@
 #nullable disable
 
 using System;
-using System.Collections.Generic;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -241,7 +240,7 @@ namespace Azure.ResourceManager.Resources
             }
         }
 
-        internal Azure.Core.HttpMessage CreateUpdateRequest(string subscriptionId, string resourceGroupName, string jitRequestName, IDictionary<string, string> tags)
+        internal Azure.Core.HttpMessage CreateUpdateRequest(string subscriptionId, string resourceGroupName, string jitRequestName, JitRequestPatchable parameters)
         {
             var message = _pipeline.CreateMessage();
             var request = message.Request;
@@ -258,17 +257,8 @@ namespace Azure.ResourceManager.Resources
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             request.Headers.Add("Content-Type", "application/json");
-            JitRequestPatchable jitRequestPatchable = new JitRequestPatchable();
-            if (tags != null)
-            {
-                foreach (var value in tags)
-                {
-                    jitRequestPatchable.Tags.Add(value);
-                }
-            }
-            var model = jitRequestPatchable;
             var content = new Utf8JsonRequestContent();
-            content.JsonWriter.WriteObjectValue(model);
+            content.JsonWriter.WriteObjectValue(parameters);
             request.Content = content;
             message.SetProperty("UserAgentOverride", _userAgent);
             return message;
@@ -278,10 +268,10 @@ namespace Azure.ResourceManager.Resources
         /// <param name="subscriptionId"> The Microsoft Azure subscription ID. </param>
         /// <param name="resourceGroupName"> The name of the resource group. The name is case insensitive. </param>
         /// <param name="jitRequestName"> The name of the JIT request. </param>
-        /// <param name="tags"> Jit request tags. </param>
+        /// <param name="parameters"> Parameters supplied to the update JIT request. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="subscriptionId"/>, <paramref name="resourceGroupName"/>, or <paramref name="jitRequestName"/> is null. </exception>
-        public async Task<Response<JitRequestDefinitionData>> UpdateAsync(string subscriptionId, string resourceGroupName, string jitRequestName, IDictionary<string, string> tags = null, CancellationToken cancellationToken = default)
+        /// <exception cref="ArgumentNullException"> <paramref name="subscriptionId"/>, <paramref name="resourceGroupName"/>, <paramref name="jitRequestName"/>, or <paramref name="parameters"/> is null. </exception>
+        public async Task<Response<JitRequestDefinitionData>> UpdateAsync(string subscriptionId, string resourceGroupName, string jitRequestName, JitRequestPatchable parameters, CancellationToken cancellationToken = default)
         {
             if (subscriptionId == null)
             {
@@ -295,8 +285,12 @@ namespace Azure.ResourceManager.Resources
             {
                 throw new ArgumentNullException(nameof(jitRequestName));
             }
+            if (parameters == null)
+            {
+                throw new ArgumentNullException(nameof(parameters));
+            }
 
-            using var message = CreateUpdateRequest(subscriptionId, resourceGroupName, jitRequestName, tags);
+            using var message = CreateUpdateRequest(subscriptionId, resourceGroupName, jitRequestName, parameters);
             await _pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
             switch (message.Response.Status)
             {
@@ -316,10 +310,10 @@ namespace Azure.ResourceManager.Resources
         /// <param name="subscriptionId"> The Microsoft Azure subscription ID. </param>
         /// <param name="resourceGroupName"> The name of the resource group. The name is case insensitive. </param>
         /// <param name="jitRequestName"> The name of the JIT request. </param>
-        /// <param name="tags"> Jit request tags. </param>
+        /// <param name="parameters"> Parameters supplied to the update JIT request. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="subscriptionId"/>, <paramref name="resourceGroupName"/>, or <paramref name="jitRequestName"/> is null. </exception>
-        public Response<JitRequestDefinitionData> Update(string subscriptionId, string resourceGroupName, string jitRequestName, IDictionary<string, string> tags = null, CancellationToken cancellationToken = default)
+        /// <exception cref="ArgumentNullException"> <paramref name="subscriptionId"/>, <paramref name="resourceGroupName"/>, <paramref name="jitRequestName"/>, or <paramref name="parameters"/> is null. </exception>
+        public Response<JitRequestDefinitionData> Update(string subscriptionId, string resourceGroupName, string jitRequestName, JitRequestPatchable parameters, CancellationToken cancellationToken = default)
         {
             if (subscriptionId == null)
             {
@@ -333,8 +327,12 @@ namespace Azure.ResourceManager.Resources
             {
                 throw new ArgumentNullException(nameof(jitRequestName));
             }
+            if (parameters == null)
+            {
+                throw new ArgumentNullException(nameof(parameters));
+            }
 
-            using var message = CreateUpdateRequest(subscriptionId, resourceGroupName, jitRequestName, tags);
+            using var message = CreateUpdateRequest(subscriptionId, resourceGroupName, jitRequestName, parameters);
             _pipeline.Send(message, cancellationToken);
             switch (message.Response.Status)
             {

--- a/sdk/resources/Azure.ResourceManager.Resources/src/Generated/RestOperations/TemplateSpecVersionsRestOperations.cs
+++ b/sdk/resources/Azure.ResourceManager.Resources/src/Generated/RestOperations/TemplateSpecVersionsRestOperations.cs
@@ -6,7 +6,6 @@
 #nullable disable
 
 using System;
-using System.Collections.Generic;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -165,7 +164,7 @@ namespace Azure.ResourceManager.Resources
             }
         }
 
-        internal Azure.Core.HttpMessage CreateUpdateRequest(string subscriptionId, string resourceGroupName, string templateSpecName, string templateSpecVersion, IDictionary<string, string> tags)
+        internal Azure.Core.HttpMessage CreateUpdateRequest(string subscriptionId, string resourceGroupName, string templateSpecName, string templateSpecVersion, TemplateSpecVersionUpdateModel templateSpecVersionUpdateModel)
         {
             var message = _pipeline.CreateMessage();
             var request = message.Request;
@@ -183,19 +182,13 @@ namespace Azure.ResourceManager.Resources
             uri.AppendQuery("api-version", apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
-            request.Headers.Add("Content-Type", "application/json");
-            TemplateSpecVersionUpdateModel templateSpecVersionUpdateModel = new TemplateSpecVersionUpdateModel();
-            if (tags != null)
+            if (templateSpecVersionUpdateModel != null)
             {
-                foreach (var value in tags)
-                {
-                    templateSpecVersionUpdateModel.Tags.Add(value);
-                }
+                request.Headers.Add("Content-Type", "application/json");
+                var content = new Utf8JsonRequestContent();
+                content.JsonWriter.WriteObjectValue(templateSpecVersionUpdateModel);
+                request.Content = content;
             }
-            var model = templateSpecVersionUpdateModel;
-            var content = new Utf8JsonRequestContent();
-            content.JsonWriter.WriteObjectValue(model);
-            request.Content = content;
             message.SetProperty("UserAgentOverride", _userAgent);
             return message;
         }
@@ -205,10 +198,10 @@ namespace Azure.ResourceManager.Resources
         /// <param name="resourceGroupName"> The name of the resource group. The name is case insensitive. </param>
         /// <param name="templateSpecName"> Name of the Template Spec. </param>
         /// <param name="templateSpecVersion"> The version of the Template Spec. </param>
-        /// <param name="tags"> Resource tags. </param>
+        /// <param name="templateSpecVersionUpdateModel"> Template Spec Version resource with the tags to be updated. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="subscriptionId"/>, <paramref name="resourceGroupName"/>, <paramref name="templateSpecName"/>, or <paramref name="templateSpecVersion"/> is null. </exception>
-        public async Task<Response<TemplateSpecVersionData>> UpdateAsync(string subscriptionId, string resourceGroupName, string templateSpecName, string templateSpecVersion, IDictionary<string, string> tags = null, CancellationToken cancellationToken = default)
+        public async Task<Response<TemplateSpecVersionData>> UpdateAsync(string subscriptionId, string resourceGroupName, string templateSpecName, string templateSpecVersion, TemplateSpecVersionUpdateModel templateSpecVersionUpdateModel = null, CancellationToken cancellationToken = default)
         {
             if (subscriptionId == null)
             {
@@ -227,7 +220,7 @@ namespace Azure.ResourceManager.Resources
                 throw new ArgumentNullException(nameof(templateSpecVersion));
             }
 
-            using var message = CreateUpdateRequest(subscriptionId, resourceGroupName, templateSpecName, templateSpecVersion, tags);
+            using var message = CreateUpdateRequest(subscriptionId, resourceGroupName, templateSpecName, templateSpecVersion, templateSpecVersionUpdateModel);
             await _pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
             switch (message.Response.Status)
             {
@@ -248,10 +241,10 @@ namespace Azure.ResourceManager.Resources
         /// <param name="resourceGroupName"> The name of the resource group. The name is case insensitive. </param>
         /// <param name="templateSpecName"> Name of the Template Spec. </param>
         /// <param name="templateSpecVersion"> The version of the Template Spec. </param>
-        /// <param name="tags"> Resource tags. </param>
+        /// <param name="templateSpecVersionUpdateModel"> Template Spec Version resource with the tags to be updated. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="subscriptionId"/>, <paramref name="resourceGroupName"/>, <paramref name="templateSpecName"/>, or <paramref name="templateSpecVersion"/> is null. </exception>
-        public Response<TemplateSpecVersionData> Update(string subscriptionId, string resourceGroupName, string templateSpecName, string templateSpecVersion, IDictionary<string, string> tags = null, CancellationToken cancellationToken = default)
+        public Response<TemplateSpecVersionData> Update(string subscriptionId, string resourceGroupName, string templateSpecName, string templateSpecVersion, TemplateSpecVersionUpdateModel templateSpecVersionUpdateModel = null, CancellationToken cancellationToken = default)
         {
             if (subscriptionId == null)
             {
@@ -270,7 +263,7 @@ namespace Azure.ResourceManager.Resources
                 throw new ArgumentNullException(nameof(templateSpecVersion));
             }
 
-            using var message = CreateUpdateRequest(subscriptionId, resourceGroupName, templateSpecName, templateSpecVersion, tags);
+            using var message = CreateUpdateRequest(subscriptionId, resourceGroupName, templateSpecName, templateSpecVersion, templateSpecVersionUpdateModel);
             _pipeline.Send(message, cancellationToken);
             switch (message.Response.Status)
             {

--- a/sdk/resources/Azure.ResourceManager.Resources/src/Generated/RestOperations/TemplateSpecsRestOperations.cs
+++ b/sdk/resources/Azure.ResourceManager.Resources/src/Generated/RestOperations/TemplateSpecsRestOperations.cs
@@ -6,7 +6,6 @@
 #nullable disable
 
 using System;
-using System.Collections.Generic;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -153,7 +152,7 @@ namespace Azure.ResourceManager.Resources
             }
         }
 
-        internal Azure.Core.HttpMessage CreateUpdateRequest(string subscriptionId, string resourceGroupName, string templateSpecName, IDictionary<string, string> tags)
+        internal Azure.Core.HttpMessage CreateUpdateRequest(string subscriptionId, string resourceGroupName, string templateSpecName, TemplateSpecUpdateModel templateSpec)
         {
             var message = _pipeline.CreateMessage();
             var request = message.Request;
@@ -169,19 +168,13 @@ namespace Azure.ResourceManager.Resources
             uri.AppendQuery("api-version", apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
-            request.Headers.Add("Content-Type", "application/json");
-            TemplateSpecUpdateModel templateSpecUpdateModel = new TemplateSpecUpdateModel();
-            if (tags != null)
+            if (templateSpec != null)
             {
-                foreach (var value in tags)
-                {
-                    templateSpecUpdateModel.Tags.Add(value);
-                }
+                request.Headers.Add("Content-Type", "application/json");
+                var content = new Utf8JsonRequestContent();
+                content.JsonWriter.WriteObjectValue(templateSpec);
+                request.Content = content;
             }
-            var model = templateSpecUpdateModel;
-            var content = new Utf8JsonRequestContent();
-            content.JsonWriter.WriteObjectValue(model);
-            request.Content = content;
             message.SetProperty("UserAgentOverride", _userAgent);
             return message;
         }
@@ -190,10 +183,10 @@ namespace Azure.ResourceManager.Resources
         /// <param name="subscriptionId"> The Microsoft Azure subscription ID. </param>
         /// <param name="resourceGroupName"> The name of the resource group. The name is case insensitive. </param>
         /// <param name="templateSpecName"> Name of the Template Spec. </param>
-        /// <param name="tags"> Resource tags. </param>
+        /// <param name="templateSpec"> Template Spec resource with the tags to be updated. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="subscriptionId"/>, <paramref name="resourceGroupName"/>, or <paramref name="templateSpecName"/> is null. </exception>
-        public async Task<Response<TemplateSpecData>> UpdateAsync(string subscriptionId, string resourceGroupName, string templateSpecName, IDictionary<string, string> tags = null, CancellationToken cancellationToken = default)
+        public async Task<Response<TemplateSpecData>> UpdateAsync(string subscriptionId, string resourceGroupName, string templateSpecName, TemplateSpecUpdateModel templateSpec = null, CancellationToken cancellationToken = default)
         {
             if (subscriptionId == null)
             {
@@ -208,7 +201,7 @@ namespace Azure.ResourceManager.Resources
                 throw new ArgumentNullException(nameof(templateSpecName));
             }
 
-            using var message = CreateUpdateRequest(subscriptionId, resourceGroupName, templateSpecName, tags);
+            using var message = CreateUpdateRequest(subscriptionId, resourceGroupName, templateSpecName, templateSpec);
             await _pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
             switch (message.Response.Status)
             {
@@ -228,10 +221,10 @@ namespace Azure.ResourceManager.Resources
         /// <param name="subscriptionId"> The Microsoft Azure subscription ID. </param>
         /// <param name="resourceGroupName"> The name of the resource group. The name is case insensitive. </param>
         /// <param name="templateSpecName"> Name of the Template Spec. </param>
-        /// <param name="tags"> Resource tags. </param>
+        /// <param name="templateSpec"> Template Spec resource with the tags to be updated. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="subscriptionId"/>, <paramref name="resourceGroupName"/>, or <paramref name="templateSpecName"/> is null. </exception>
-        public Response<TemplateSpecData> Update(string subscriptionId, string resourceGroupName, string templateSpecName, IDictionary<string, string> tags = null, CancellationToken cancellationToken = default)
+        public Response<TemplateSpecData> Update(string subscriptionId, string resourceGroupName, string templateSpecName, TemplateSpecUpdateModel templateSpec = null, CancellationToken cancellationToken = default)
         {
             if (subscriptionId == null)
             {
@@ -246,7 +239,7 @@ namespace Azure.ResourceManager.Resources
                 throw new ArgumentNullException(nameof(templateSpecName));
             }
 
-            using var message = CreateUpdateRequest(subscriptionId, resourceGroupName, templateSpecName, tags);
+            using var message = CreateUpdateRequest(subscriptionId, resourceGroupName, templateSpecName, templateSpec);
             _pipeline.Send(message, cancellationToken);
             switch (message.Response.Status)
             {

--- a/sdk/resources/Azure.ResourceManager.Resources/src/Generated/TemplateSpec.cs
+++ b/sdk/resources/Azure.ResourceManager.Resources/src/Generated/TemplateSpec.cs
@@ -228,15 +228,15 @@ namespace Azure.ResourceManager.Resources
         }
 
         /// <summary> Updates Template Spec tags with specified values. </summary>
-        /// <param name="tags"> Resource tags. </param>
+        /// <param name="templateSpec"> Template Spec resource with the tags to be updated. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public async virtual Task<Response<TemplateSpec>> UpdateAsync(IDictionary<string, string> tags = null, CancellationToken cancellationToken = default)
+        public async virtual Task<Response<TemplateSpec>> UpdateAsync(TemplateSpecUpdateModel templateSpec = null, CancellationToken cancellationToken = default)
         {
             using var scope = _clientDiagnostics.CreateScope("TemplateSpec.Update");
             scope.Start();
             try
             {
-                var response = await _templateSpecsRestClient.UpdateAsync(Id.SubscriptionId, Id.ResourceGroupName, Id.Name, tags, cancellationToken).ConfigureAwait(false);
+                var response = await _templateSpecsRestClient.UpdateAsync(Id.SubscriptionId, Id.ResourceGroupName, Id.Name, templateSpec, cancellationToken).ConfigureAwait(false);
                 return Response.FromValue(new TemplateSpec(this, response.Value), response.GetRawResponse());
             }
             catch (Exception e)
@@ -247,15 +247,15 @@ namespace Azure.ResourceManager.Resources
         }
 
         /// <summary> Updates Template Spec tags with specified values. </summary>
-        /// <param name="tags"> Resource tags. </param>
+        /// <param name="templateSpec"> Template Spec resource with the tags to be updated. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public virtual Response<TemplateSpec> Update(IDictionary<string, string> tags = null, CancellationToken cancellationToken = default)
+        public virtual Response<TemplateSpec> Update(TemplateSpecUpdateModel templateSpec = null, CancellationToken cancellationToken = default)
         {
             using var scope = _clientDiagnostics.CreateScope("TemplateSpec.Update");
             scope.Start();
             try
             {
-                var response = _templateSpecsRestClient.Update(Id.SubscriptionId, Id.ResourceGroupName, Id.Name, tags, cancellationToken);
+                var response = _templateSpecsRestClient.Update(Id.SubscriptionId, Id.ResourceGroupName, Id.Name, templateSpec, cancellationToken);
                 return Response.FromValue(new TemplateSpec(this, response.Value), response.GetRawResponse());
             }
             catch (Exception e)

--- a/sdk/resources/Azure.ResourceManager.Resources/src/Generated/TemplateSpecVersion.cs
+++ b/sdk/resources/Azure.ResourceManager.Resources/src/Generated/TemplateSpecVersion.cs
@@ -226,15 +226,15 @@ namespace Azure.ResourceManager.Resources
         }
 
         /// <summary> Updates Template Spec Version tags with specified values. </summary>
-        /// <param name="tags"> Resource tags. </param>
+        /// <param name="templateSpecVersionUpdateModel"> Template Spec Version resource with the tags to be updated. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public async virtual Task<Response<TemplateSpecVersion>> UpdateAsync(IDictionary<string, string> tags = null, CancellationToken cancellationToken = default)
+        public async virtual Task<Response<TemplateSpecVersion>> UpdateAsync(TemplateSpecVersionUpdateModel templateSpecVersionUpdateModel = null, CancellationToken cancellationToken = default)
         {
             using var scope = _clientDiagnostics.CreateScope("TemplateSpecVersion.Update");
             scope.Start();
             try
             {
-                var response = await _templateSpecVersionsRestClient.UpdateAsync(Id.SubscriptionId, Id.ResourceGroupName, Id.Parent.Name, Id.Name, tags, cancellationToken).ConfigureAwait(false);
+                var response = await _templateSpecVersionsRestClient.UpdateAsync(Id.SubscriptionId, Id.ResourceGroupName, Id.Parent.Name, Id.Name, templateSpecVersionUpdateModel, cancellationToken).ConfigureAwait(false);
                 return Response.FromValue(new TemplateSpecVersion(this, response.Value), response.GetRawResponse());
             }
             catch (Exception e)
@@ -245,15 +245,15 @@ namespace Azure.ResourceManager.Resources
         }
 
         /// <summary> Updates Template Spec Version tags with specified values. </summary>
-        /// <param name="tags"> Resource tags. </param>
+        /// <param name="templateSpecVersionUpdateModel"> Template Spec Version resource with the tags to be updated. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public virtual Response<TemplateSpecVersion> Update(IDictionary<string, string> tags = null, CancellationToken cancellationToken = default)
+        public virtual Response<TemplateSpecVersion> Update(TemplateSpecVersionUpdateModel templateSpecVersionUpdateModel = null, CancellationToken cancellationToken = default)
         {
             using var scope = _clientDiagnostics.CreateScope("TemplateSpecVersion.Update");
             scope.Start();
             try
             {
-                var response = _templateSpecVersionsRestClient.Update(Id.SubscriptionId, Id.ResourceGroupName, Id.Parent.Name, Id.Name, tags, cancellationToken);
+                var response = _templateSpecVersionsRestClient.Update(Id.SubscriptionId, Id.ResourceGroupName, Id.Parent.Name, Id.Name, templateSpecVersionUpdateModel, cancellationToken);
                 return Response.FromValue(new TemplateSpecVersion(this, response.Value), response.GetRawResponse());
             }
             catch (Exception e)


### PR DESCRIPTION
# All SDK Contribution checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.
- [ ] **Please open PR in `Draft` mode if it is:**
	- Work in progress or not intended to be merged.
	- Encountering multiple pipeline failures and working on fixes.
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/master/CONTRIBUTING.md).**
- [ ] **The pull request does not introduce [breaking changes](https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/breaking-change-rules.md).**

### [General Guidelines and Best Practices](https://github.com/Azure/azure-sdk-for-net/blob/master/CONTRIBUTING.md#general-guidelines)
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/master/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/master/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code. (Track 2 only)
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK. Please double check nuget.org current release version.

## Additional management plane SDK specific contribution checklist: 
Note: Only applies to `Microsoft.Azure.Management.[RP]` or `Azure.ResourceManager.[RP]`
 
- [ ] Include updated [management metadata](https://github.com/Azure/azure-sdk-for-net/tree/master/eng/mgmt/mgmtmetadata).
- [ ] Update AzureRP.props to add/remove version info to maintain up to date API versions.

### Management plane SDK Troubleshooting
- If this is very first SDK for a services and you are adding new service folders directly under /SDK, please add `new service` label and/or contact assigned reviewer.
- If the check fails at the `Verify Code Generation` step, please ensure:
	- Do not modify any code in generated folders.
	- Do not selectively include/remove generated files in the PR.
	- Do use `generate.ps1/cmd` to generate this PR instead of calling `autorest` directly.
	Please pay attention to the @microsoft.csharp version output after running `generate.ps1`. If it is lower than current released version (2.3.82), please run it again as it should pull down the latest version.
	
	**Note: We have recently updated the PSH module called by `generate.ps1` to emit additional data. This would help reduce/eliminate the Code Verification check error. Please run following command**:

	    `dotnet msbuild eng/mgmt.proj /t:Util /p:UtilityName=InstallPsModules`

### Old outstanding PR cleanup
 Please note:
	If PRs (including draft) has been out for more than 60 days and there are no responses from our query or followups, they will be closed to maintain a concise list for our reviewers.
